### PR TITLE
fix(ui): Prevent modal from being stuck open on page load.

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -169,17 +169,23 @@ document.addEventListener('DOMContentLoaded', () => {
     const showModal = () => modal.classList.remove('hidden');
     const hideModal = () => modal.classList.add('hidden');
 
-    closeModalBtn.addEventListener('click', hideModal);
-    modal.addEventListener('click', (e) => {
-        if (e.target === modal) hideModal();
-    });
-    copyAllBtn.addEventListener('click', () => {
-        modalLinks.select();
-        navigator.clipboard.writeText(modalLinks.value).then(() => {
-            showToast('تمام لینک‌ها با موفقیت کپی شد!');
-            hideModal();
+    if(closeModalBtn) {
+        closeModalBtn.addEventListener('click', hideModal);
+    }
+    if(modal) {
+        modal.addEventListener('click', (e) => {
+            if (e.target === modal) hideModal();
         });
-    });
+    }
+    if(copyAllBtn) {
+        copyAllBtn.addEventListener('click', () => {
+            modalLinks.select();
+            navigator.clipboard.writeText(modalLinks.value).then(() => {
+                showToast('تمام لینک‌ها با موفقیت کپی شد!');
+                hideModal();
+            });
+        });
+    }
 
     // --- Event Delegation for Dynamic Buttons ---
     resultsArea.addEventListener('click', (e) => {

--- a/assets/style.css
+++ b/assets/style.css
@@ -103,7 +103,7 @@ textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3
     z-index: 2000;
 }
 .modal-overlay.hidden {
-    display: none;
+    display: none !important;
 }
 .modal-content {
     background-color: var(--card-bg); color: var(--text);


### PR DESCRIPTION
This commit fixes a critical regression where the 'Download All' modal would appear on page load and could not be closed.

1.  The JavaScript event listeners for the modal's buttons are now wrapped in defensive `if` blocks. This prevents the script from crashing if an element isn't found, ensuring the close handlers are always attached.
2.  The CSS rule to hide the modal by default has been made more forceful with `!important` to prevent any potential style conflicts.